### PR TITLE
Update testnetv4.json

### DIFF
--- a/src/tokens/testnetv4.json
+++ b/src/tokens/testnetv4.json
@@ -54,7 +54,7 @@
       "symbol": "KAN",
       "description": "The first collaborative and decentralized canvas, based on the first fee-less smart-contract blockchain.",
       "decimals": "8",
-      "logoURI": "https://raw.githubusercontent.com/koindx/token-list/main/src/images/testnet/1LeWGhDVD8g5rGCL4aDegEf9fKyTL1KhsS.png",
+      "logoURI": "https://raw.githubusercontent.com/koindx/token-list/main/src/images/testnetv4/1LeWGhDVD8g5rGCL4aDegEf9fKyTL1KhsS.png",
       "address": "1LeWGhDVD8g5rGCL4aDegEf9fKyTL1KhsS",
       "allowance": true,
       "token_website": "https://kanvas-app.com",


### PR DESCRIPTION
This PR changes a part of the logoURI **testnet** to **testnetv4**

fix: error in kanvas testnet image URI 