### PR TITLE
rename tokens wrapped of chainge

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -26,7 +26,7 @@
       "coinmarketcap_id": ""
     },
     {
-      "name": "Ethereum",
+      "name": "Chainge ETH",
       "symbol": "ETH",
       "description": "Wrapped Ethereum via chainge finance.",
       "decimals": "8",
@@ -38,7 +38,7 @@
       "coinmarketcap_id": ""
     },
     {
-      "name": "Tether USD",
+      "name": "Chainge USDT",
       "symbol": "USDT",
       "description": "Wrapped Tether USD via chainge finance.",
       "decimals": "8",


### PR DESCRIPTION
The word chainge was added to the name of the wrapped tokens delivered by chainge to avoid confusion.